### PR TITLE
Support for vaccine preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Flags:
   -p, --password string   Email ID password for auth
   -c, --pincode string    Search by pin code
   -s, --state string      Search by state name
+  -v, --vaccine int       Vaccine preferences - (1) Covishield, (2) Covaxin. Default: (0) no preference
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Flags:
   -p, --password string   Email ID password for auth
   -c, --pincode string    Search by pin code
   -s, --state string      Search by state name
-  -v, --vaccine int       Vaccine preferences - (1) Covishield, (2) Covaxin. Default: (0) no preference
+  -v, --vaccine string    Vaccine preferences - covishield (or) covaxin. Default: No preference
 
 ```
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 var (
 	pinCode, state, district, email, password, date string
 
-	age, interval int
+	age, interval, vaccine int
 
 	rootCmd = &cobra.Command{
 		Use:   "covaccine-notifier [FLAGS]",
@@ -33,8 +33,10 @@ const (
 	emailIDEnv        = "EMAIL_ID"
 	emailPasswordEnv  = "EMAIL_PASSOWORD"
 	searchIntervalEnv = "SEARCH_INTERVAL"
+	VaccineEnv        = "VACCINE"
 
-	defaultSearchInterval = 60
+	defaultSearchInterval    = 60
+	defaultVaccinePreference = 0
 )
 
 func init() {
@@ -45,6 +47,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&email, "email", "e", os.Getenv(emailIDEnv), "Email address to send notifications")
 	rootCmd.PersistentFlags().StringVarP(&password, "password", "p", os.Getenv(emailPasswordEnv), "Email ID password for auth")
 	rootCmd.PersistentFlags().IntVarP(&interval, "interval", "i", getIntEnv(searchIntervalEnv), fmt.Sprintf("Interval to repeat the search. Default: (%v) second", defaultSearchInterval))
+	rootCmd.PersistentFlags().IntVarP(&vaccine, "vaccine", "v", getIntEnv(VaccineEnv), fmt.Sprintf("Vaccine preferences - (1) Covishield, (2) Covaxin. Default: (%v) no preference", defaultVaccinePreference))
 
 }
 
@@ -70,6 +73,9 @@ func checkFlags() error {
 	}
 	if interval == 0 {
 		interval = defaultSearchInterval
+	}
+	if vaccine < 0 || vaccine > 2 {
+		return errors.New("Vaccine values can only be 0, 1 or 2")
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ const (
 	emailIDEnv        = "EMAIL_ID"
 	emailPasswordEnv  = "EMAIL_PASSOWORD"
 	searchIntervalEnv = "SEARCH_INTERVAL"
-	VaccineEnv        = "VACCINE"
+	vaccineEnv        = "VACCINE"
 
 	defaultSearchInterval = 60
 
@@ -49,7 +49,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&email, "email", "e", os.Getenv(emailIDEnv), "Email address to send notifications")
 	rootCmd.PersistentFlags().StringVarP(&password, "password", "p", os.Getenv(emailPasswordEnv), "Email ID password for auth")
 	rootCmd.PersistentFlags().IntVarP(&interval, "interval", "i", getIntEnv(searchIntervalEnv), fmt.Sprintf("Interval to repeat the search. Default: (%v) second", defaultSearchInterval))
-	rootCmd.PersistentFlags().StringVarP(&vaccine, "vaccine", "v", os.Getenv(VaccineEnv), fmt.Sprintf("Vaccine preferences - covishield (or) covaxin. Default: No preference"))
+	rootCmd.PersistentFlags().StringVarP(&vaccine, "vaccine", "v", os.Getenv(vaccineEnv), fmt.Sprintf("Vaccine preferences - covishield (or) covaxin. Default: No preference"))
 }
 
 // Execute executes the main command

--- a/main.go
+++ b/main.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	pinCode, state, district, email, password, date string
+	pinCode, state, district, email, password, date, vaccine string
 
-	age, interval, vaccine int
+	age, interval int
 
 	rootCmd = &cobra.Command{
 		Use:   "covaccine-notifier [FLAGS]",
@@ -35,8 +35,10 @@ const (
 	searchIntervalEnv = "SEARCH_INTERVAL"
 	VaccineEnv        = "VACCINE"
 
-	defaultSearchInterval    = 60
-	defaultVaccinePreference = 0
+	defaultSearchInterval = 60
+
+	covishield = "covishield"
+	covaxin    = "covaxin"
 )
 
 func init() {
@@ -47,8 +49,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&email, "email", "e", os.Getenv(emailIDEnv), "Email address to send notifications")
 	rootCmd.PersistentFlags().StringVarP(&password, "password", "p", os.Getenv(emailPasswordEnv), "Email ID password for auth")
 	rootCmd.PersistentFlags().IntVarP(&interval, "interval", "i", getIntEnv(searchIntervalEnv), fmt.Sprintf("Interval to repeat the search. Default: (%v) second", defaultSearchInterval))
-	rootCmd.PersistentFlags().IntVarP(&vaccine, "vaccine", "v", getIntEnv(VaccineEnv), fmt.Sprintf("Vaccine preferences - (1) Covishield, (2) Covaxin. Default: (%v) no preference", defaultVaccinePreference))
-
+	rootCmd.PersistentFlags().StringVarP(&vaccine, "vaccine", "v", os.Getenv(VaccineEnv), fmt.Sprintf("Vaccine preferences - Covishield (or) Covaxin. Default: No preference"))
 }
 
 // Execute executes the main command
@@ -74,8 +75,8 @@ func checkFlags() error {
 	if interval == 0 {
 		interval = defaultSearchInterval
 	}
-	if vaccine < 0 || vaccine > 2 {
-		return errors.New("Vaccine values can only be 0, 1 or 2")
+	if !(vaccine == "" || vaccine == covishield || vaccine == covaxin) {
+		return errors.New("Invalid vaccine, please use covaxin or covishield")
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&email, "email", "e", os.Getenv(emailIDEnv), "Email address to send notifications")
 	rootCmd.PersistentFlags().StringVarP(&password, "password", "p", os.Getenv(emailPasswordEnv), "Email ID password for auth")
 	rootCmd.PersistentFlags().IntVarP(&interval, "interval", "i", getIntEnv(searchIntervalEnv), fmt.Sprintf("Interval to repeat the search. Default: (%v) second", defaultSearchInterval))
-	rootCmd.PersistentFlags().StringVarP(&vaccine, "vaccine", "v", os.Getenv(VaccineEnv), fmt.Sprintf("Vaccine preferences - Covishield (or) Covaxin. Default: No preference"))
+	rootCmd.PersistentFlags().StringVarP(&vaccine, "vaccine", "v", os.Getenv(VaccineEnv), fmt.Sprintf("Vaccine preferences - covishield (or) covaxin. Default: No preference"))
 }
 
 // Execute executes the main command

--- a/search.go
+++ b/search.go
@@ -21,9 +21,6 @@ const (
 	calendarByDistrictURLFormat = "/v2/appointment/sessions/calendarByDistrict?district_id=%d&date=%s"
 	listStatesURLFormat         = "/v2/admin/location/states"
 	listDistrictsURLFormat      = "/v2/admin/location/districts/%d"
-
-	covishield = "covishield"
-	covaxin    = "covaxin"
 )
 
 var (
@@ -184,13 +181,13 @@ func searchByStateDistrict(age int, state, district string) error {
 }
 
 // isPreferredVaccineAvailable checks for availability of preferred vaccine
-func isPreferredVaccineAvailable(current string, preference int) bool {
+func isPreferredVaccineAvailable(current, preference string) bool {
 	switch preference {
-	case 0:
+	case "":
 		return true
-	case 1:
+	case covishield:
 		return strings.ToLower(current) == covishield
-	case 2:
+	case covaxin:
 		return strings.ToLower(current) == covaxin
 	}
 


### PR DESCRIPTION
This PR adds support for specifying vaccine preferences, if any.
If a preference is specified, results will contain only the preferred vaccine.