### PR TITLE
Add command-line option to filter on available vaccination capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,17 @@ Usage:
   covaccine-notifier [FLAGS] [flags]
 
 Flags:
-  -a, --age int           Search appointment for age
-  -d, --district string   Search by district name
-  -e, --email string      Email address to send notifications
-  -f, --fee string        Fee preferences - free (or) paid. Default: No preference
-  -h, --help              help for covaccine-notifier
-  -i, --interval int      Interval to repeat the search. Default: (60) second
-  -p, --password string   Email ID password for auth
-  -c, --pincode string    Search by pin code
-  -s, --state string      Search by state name
-  -v, --vaccine string    Vaccine preferences - covishield (or) covaxin. Default: No preference
+  -h, --help                help for covaccine-notifier
+  -a, --age int             Search appointment for age
+  -s, --state string        Search by state name
+  -d, --district string     Search by district name
+  -c, --pincode string      Search by pin code
+  -e, --email string        Email address to send notifications
+  -p, --password string     Email ID password for auth
+  -i, --interval int        Interval to repeat the search. Default: (60) second
+  -f, --fee string          Fee preferences - free (or) paid. Default: No preference
+  -v, --vaccine string      Vaccine preferences - covishield (or) covaxin. Default: No preference
+  -m, --minCapacity int     Filter by minimum vaccination capacity. Default: 1
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Flags:
   -i, --interval int        Interval to repeat the search. Default: (60) second
   -f, --fee string          Fee preferences - free (or) paid. Default: No preference
   -v, --vaccine string      Vaccine preferences - covishield (or) covaxin. Default: No preference
-  -m, --minCapacity int     Filter by minimum vaccination capacity. Default: 1
+  -m, --min-capacity int     Filter by minimum vaccination capacity. Default: 1
 
 ```
 

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ const (
 	minCapacityEnv    = "MIN_CAPACITY"
 
 	defaultSearchInterval = 60
-	defaultMinCapacity = 1
+	defaultMinCapacity    = 1
 
 	covishield = "covishield"
 	covaxin    = "covaxin"
@@ -57,7 +57,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVarP(&interval, "interval", "i", getIntEnv(searchIntervalEnv), fmt.Sprintf("Interval to repeat the search. Default: (%v) second", defaultSearchInterval))
 	rootCmd.PersistentFlags().StringVarP(&vaccine, "vaccine", "v", os.Getenv(vaccineEnv), fmt.Sprintf("Vaccine preferences - covishield (or) covaxin. Default: No preference"))
 	rootCmd.PersistentFlags().StringVarP(&fee, "fee", "f", os.Getenv(feeEnv), fmt.Sprintf("Fee preferences - free (or) paid. Default: No preference"))
-    rootCmd.PersistentFlags().IntVarP(&minCapacity, "min-capacity", "m", getIntEnv(minCapacityEnv), fmt.Sprintf("Filter by minimum vaccination capacity. Default: (%v)", defaultMinCapacity))
+	rootCmd.PersistentFlags().IntVarP(&minCapacity, "min-capacity", "m", getIntEnv(minCapacityEnv), fmt.Sprintf("Filter by minimum vaccination capacity. Default: (%v)", defaultMinCapacity))
 }
 
 // Execute executes the main command
@@ -90,7 +90,7 @@ func checkFlags() error {
 		return errors.New("Invalid fee preference, please use free or paid")
 	}
 	if minCapacity == 0 {
-	    minCapacity = defaultMinCapacity
+		minCapacity = defaultMinCapacity
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVarP(&interval, "interval", "i", getIntEnv(searchIntervalEnv), fmt.Sprintf("Interval to repeat the search. Default: (%v) second", defaultSearchInterval))
 	rootCmd.PersistentFlags().StringVarP(&vaccine, "vaccine", "v", os.Getenv(vaccineEnv), fmt.Sprintf("Vaccine preferences - covishield (or) covaxin. Default: No preference"))
 	rootCmd.PersistentFlags().StringVarP(&fee, "fee", "f", os.Getenv(feeEnv), fmt.Sprintf("Fee preferences - free (or) paid. Default: No preference"))
-    rootCmd.PersistentFlags().IntVarP(&minCapacity, "minCapacity", "m", getIntEnv(minCapacityEnv), fmt.Sprintf("Filter by minimum vaccination capacity. Default: (%v)", defaultMinCapacity))
+    rootCmd.PersistentFlags().IntVarP(&minCapacity, "min-capacity", "m", getIntEnv(minCapacityEnv), fmt.Sprintf("Filter by minimum vaccination capacity. Default: (%v)", defaultMinCapacity))
 }
 
 // Execute executes the main command

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 var (
 	pinCode, state, district, email, password, date, vaccine, fee string
 
-	age, interval int
+	age, interval, minCapacity int
 
 	rootCmd = &cobra.Command{
 		Use:   "covaccine-notifier [FLAGS]",
@@ -35,8 +35,10 @@ const (
 	searchIntervalEnv = "SEARCH_INTERVAL"
 	vaccineEnv        = "VACCINE"
 	feeEnv            = "FEE"
+	minCapacityEnv    = "MIN_CAPACITY"
 
 	defaultSearchInterval = 60
+	defaultMinCapacity = 1
 
 	covishield = "covishield"
 	covaxin    = "covaxin"
@@ -55,6 +57,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVarP(&interval, "interval", "i", getIntEnv(searchIntervalEnv), fmt.Sprintf("Interval to repeat the search. Default: (%v) second", defaultSearchInterval))
 	rootCmd.PersistentFlags().StringVarP(&vaccine, "vaccine", "v", os.Getenv(vaccineEnv), fmt.Sprintf("Vaccine preferences - covishield (or) covaxin. Default: No preference"))
 	rootCmd.PersistentFlags().StringVarP(&fee, "fee", "f", os.Getenv(feeEnv), fmt.Sprintf("Fee preferences - free (or) paid. Default: No preference"))
+    rootCmd.PersistentFlags().IntVarP(&minCapacity, "minCapacity", "m", getIntEnv(minCapacityEnv), fmt.Sprintf("Filter by minimum vaccination capacity. Default: (%v)", defaultMinCapacity))
 }
 
 // Execute executes the main command
@@ -85,6 +88,9 @@ func checkFlags() error {
 	}
 	if !(fee == "" || fee == free || fee == paid) {
 		return errors.New("Invalid fee preference, please use free or paid")
+	}
+	if minCapacity == 0 {
+	    minCapacity = defaultMinCapacity
 	}
 	return nil
 }

--- a/search.go
+++ b/search.go
@@ -206,7 +206,7 @@ func getAvailableSessions(response []byte, age int, minCapacity int) error {
 			continue
 		}
 		for _, s := range center.Sessions {
-			if s.MinAgeLimit <= age && s.AvailableCapacity >= minCapacity && isPreferredAvailable(s.Vaccine, vaccine) {
+			if s.MinAgeLimit <= age && s.AvailableCapacity >= float64(minCapacity) && isPreferredAvailable(s.Vaccine, vaccine) {
 				fmt.Fprintln(w, fmt.Sprintf("Center\t%s", center.Name))
 				fmt.Fprintln(w, fmt.Sprintf("State\t%s", center.StateName))
 				fmt.Fprintln(w, fmt.Sprintf("District\t%s", center.DistrictName))

--- a/search.go
+++ b/search.go
@@ -70,7 +70,7 @@ type Appointments struct {
 		Sessions []struct {
 			SessionID         string   `json:"session_id"`
 			Date              string   `json:"date"`
-			AvailableCapacity float64  `json:"available_capacity"`
+			AvailableCapacity int      `json:"available_capacity"`
 			MinAgeLimit       int      `json:"min_age_limit"`
 			Vaccine           string   `json:"vaccine"`
 			Slots             []string `json:"slots"`
@@ -120,7 +120,7 @@ func searchByPincode(pinCode string) error {
 	if err != nil {
 		return errors.Wrap(err, "Failed to fetch appointment sessions")
 	}
-	return getAvailableSessions(response, age)
+	return getAvailableSessions(response, age, minCapacity)
 }
 
 func getStateIDByName(state string) (int, error) {
@@ -177,7 +177,7 @@ func searchByStateDistrict(age int, state, district string) error {
 	if err != nil {
 		return errors.Wrap(err, "Failed to fetch appointment sessions")
 	}
-	return getAvailableSessions(response, age)
+	return getAvailableSessions(response, age, minCapacity)
 }
 
 // isPreferredAvailable checks for availability of preferences
@@ -189,7 +189,7 @@ func isPreferredAvailable(current, preference string) bool {
 	}
 }
 
-func getAvailableSessions(response []byte, age int) error {
+func getAvailableSessions(response []byte, age int, minCapacity int) error {
 	if response == nil {
 		log.Printf("Received unexpected response, rechecking after %v seconds", interval)
 		return nil
@@ -206,7 +206,7 @@ func getAvailableSessions(response []byte, age int) error {
 			continue
 		}
 		for _, s := range center.Sessions {
-			if s.MinAgeLimit <= age && s.AvailableCapacity != 0 && isPreferredAvailable(s.Vaccine, vaccine) {
+			if s.MinAgeLimit <= age && s.AvailableCapacity >= minCapacity && isPreferredAvailable(s.Vaccine, vaccine) {
 				fmt.Fprintln(w, fmt.Sprintf("Center\t%s", center.Name))
 				fmt.Fprintln(w, fmt.Sprintf("State\t%s", center.StateName))
 				fmt.Fprintln(w, fmt.Sprintf("District\t%s", center.DistrictName))
@@ -221,7 +221,7 @@ func getAvailableSessions(response []byte, age int) error {
 				}
 				fmt.Fprintln(w, fmt.Sprintf("Sessions\t"))
 				fmt.Fprintln(w, fmt.Sprintf("\tDate\t%s", s.Date))
-				fmt.Fprintln(w, fmt.Sprintf("\tAvailableCapacity\t%f", s.AvailableCapacity))
+				fmt.Fprintln(w, fmt.Sprintf("\tAvailableCapacity\t%d", s.AvailableCapacity))
 				fmt.Fprintln(w, fmt.Sprintf("\tMinAgeLimit\t%d", s.MinAgeLimit))
 				fmt.Fprintln(w, fmt.Sprintf("\tVaccine\t%s", s.Vaccine))
 				fmt.Fprintln(w, fmt.Sprintf("\tSlots"))

--- a/search.go
+++ b/search.go
@@ -70,7 +70,7 @@ type Appointments struct {
 		Sessions []struct {
 			SessionID         string   `json:"session_id"`
 			Date              string   `json:"date"`
-			AvailableCapacity int      `json:"available_capacity"`
+			AvailableCapacity float64  `json:"available_capacity"`
 			MinAgeLimit       int      `json:"min_age_limit"`
 			Vaccine           string   `json:"vaccine"`
 			Slots             []string `json:"slots"`
@@ -221,7 +221,7 @@ func getAvailableSessions(response []byte, age int, minCapacity int) error {
 				}
 				fmt.Fprintln(w, fmt.Sprintf("Sessions\t"))
 				fmt.Fprintln(w, fmt.Sprintf("\tDate\t%s", s.Date))
-				fmt.Fprintln(w, fmt.Sprintf("\tAvailableCapacity\t%d", s.AvailableCapacity))
+				fmt.Fprintln(w, fmt.Sprintf("\tAvailableCapacity\t%f", s.AvailableCapacity))
 				fmt.Fprintln(w, fmt.Sprintf("\tMinAgeLimit\t%d", s.MinAgeLimit))
 				fmt.Fprintln(w, fmt.Sprintf("\tVaccine\t%s", s.Vaccine))
 				fmt.Fprintln(w, fmt.Sprintf("\tSlots"))


### PR DESCRIPTION
This PR add command line option "minCapacity" and related logic to filter appointments which have minimum available vaccination capacity. The default value is 1.

Real-world use case is that i am looking for 2 vaccination slots but getting lot of alerts with 1 slots.